### PR TITLE
Add availability ranges to towns

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,16 +16,21 @@ This service can be used at the above endpoint with a POST call, comprising of `
   - _Note:_ if this is set to 0, the algorithm with be completely random, with no average improvement of ants over multiple iterations
 - pherememoneStrength: The baseline strength of the pheremone trail deposited by each ant
 - evaporationRate: The ratio at which the pheremones of ants from previous iterations decreases over time
-- visitQuantity: The number of towns that should be visited over the duration of the trip
+- visitQuantity: The maximum number of towns that should be visited over the duration of the trip
+- verbose: If set to `true`, additional history will be processed in the algorithm and returned to the requester in the REST call
+- tripBounds: Sets the start and end bounds of the trip. If `tripBounds.start > 0`, the trip will start counting from that point. If `tripBounds.end > 0`, the trip will end if no remaining unvisited towns can be visited without exceeding the given value.
+- minimumTripUsage: Sets a default ratio of the total time in `tripBounds` that each ant must consume before the trip ends. If an ant takes a path that eliminates any options to reach the minimum trip usage, it will reattempt to take another path until it finds one. If it reaches 100 attempts without meeting the minimum trip length, the trip will iteratively be reduced by a factor of 0.9, until the ant can complete the trip.
 
 ### Towns
 - includesHome: True or false indicating whether the first town in the provided array is a "home" location where each ant should start and return to every time. If set to false, there will be no set starting location and the starting town will be set randomly.
-- towns: the array of towns with all of the relevant properties associated as follows
+- towns: The array of towns with all of the relevant properties associated as follows
   - id: Unique id associated with the town
   - distances[]: Distances to each other location in the object. The order is assumed to be identical as the `towns` array, and the algorithm will return an error if the length of `distances` is not equal to `towns`
   - trails[]: (Optional) The pheremone trail associated with the path to the other towns in the case that the results are being sent back to the algorithm for more iterations.
   - rating: The desirability factor of the town. when `config.maximizeRating == true`, higher ratings will increase the probability that an ant will visit this town
   - isRequired: Marks the town as mandatory - If set to true while `config.visitQuantity` is less than the size of `towns.towns[]`, any ant that fails to visit this town will be considered invalid and another ant will take its place.
+  - trailHistory: Returns the trail results for each town at each iteration if `config.verbose == true`.
+  
 
   ### Sample request body
   The following is a sample request body consisting of five points arranged in a regular pentagon.

--- a/ant.go
+++ b/ant.go
@@ -8,17 +8,17 @@ import (
 
 // Ant The representation of a single entity traversing a path throughout the towns
 type Ant struct {
-	ID                 int         `json:"-"`
-	Tour               []int       `json:"tour"`
-	Visited            []bool      `json:"-"`
-	Probabilities      []float64   `json:"-"`
-	Score              float64     `json:"score"`
-	Distance           float64     `json:"distance"`
-	Rating             float64     `json:"rating"`
-	VisitSpan          [][]float64 `json:"visitSpan"`
-	costState          float64
-	availabilityBounds AvailabilityBounds
-	tourComplete       bool
+	ID            int         `json:"-"`
+	Tour          []int       `json:"tour"`
+	Visited       []bool      `json:"-"`
+	Probabilities []float64   `json:"-"`
+	Score         float64     `json:"score"`
+	Distance      float64     `json:"distance"`
+	Rating        float64     `json:"rating"`
+	VisitSpan     [][]float64 `json:"visitSpan"`
+	costState     float64
+	tripBounds    AvailabilityBounds
+	tourComplete  bool
 }
 
 // AverageResults tracks performance metrics of the ACO, such as AverageScore and MinimumScore for each Iteration
@@ -39,9 +39,9 @@ func createAnt(thisID int, townQty int, config AcoConfig) Ant {
 		Distance:      0,
 		Rating:        0,
 		VisitSpan:     [][]float64{},
-		availabilityBounds: AvailabilityBounds{
-			Start: config.AvailabilityBounds.Start,
-			End:   config.AvailabilityBounds.End,
+		tripBounds: AvailabilityBounds{
+			Start: config.TripBounds.Start,
+			End:   config.TripBounds.End,
 		},
 	}
 	return thisAnt
@@ -124,7 +124,7 @@ func (a *Ant) visitNextTown(ts Towns) {
 	(*a).Tour = append((*a).Tour, i)
 	tourLength := float64(len((*a).Tour))
 	(*a).Visited[i] = true
-	normalizedRating := ts.TownSlice[i].NormalizedRating
+	normalizedRating := ts.TownSlice[i].normalizedRating
 	if tourLength > 1 {
 		distance := ts.TownSlice[(*a).Tour[len((*a).Tour)-2]].Distances[i]
 		(*a).Score += 1 / (1/distance + normalizedRating)
@@ -207,7 +207,7 @@ func createAntSlice(n int, ts Towns, config AcoConfig) []Ant {
 }
 
 func getTourCapacityRatio(ant Ant) float64 {
-	return (ant.VisitSpan[len(ant.VisitSpan)-1][1] - ant.availabilityBounds.Start) / (ant.availabilityBounds.End - ant.availabilityBounds.Start)
+	return (ant.VisitSpan[len(ant.VisitSpan)-1][1] - ant.tripBounds.Start) / (ant.tripBounds.End - ant.tripBounds.Start)
 }
 
 func analyzeAnts(ants []Ant, bestAnts []Ant, averageArray []AverageResults) ([]Ant, []AverageResults) {
@@ -259,7 +259,7 @@ func calculateAntResults(tour []int, ts Towns) (float64, float64, float64) {
 	rating := 0.0
 	ratingSum := 0.0
 	for tourIndex, location := range tour {
-		normalizedRating := ts.TownSlice[location].NormalizedRating
+		normalizedRating := ts.TownSlice[location].normalizedRating
 		if tourIndex > 0 {
 			legDistance := ts.TownSlice[location].Distances[tour[tourIndex-1]]
 			score += 1 / (1/legDistance + normalizedRating)

--- a/ant.go
+++ b/ant.go
@@ -53,7 +53,7 @@ func (a *Ant) getProbabilityList(ts Towns) {
 		currentLocation := (*a).Tour[len((*a).Tour)-1]
 		for i := 0; i < n; i++ {
 			if !(*a).Visited[i] {
-				numerator[i] = ts.ProbabilityMatrix[currentLocation][i]
+				numerator[i] = ts.probabilityMatrix[currentLocation][i]
 				denom += numerator[i]
 			}
 		}

--- a/ant.go
+++ b/ant.go
@@ -122,6 +122,7 @@ func (a *Ant) visitNextTown(ts Towns) {
 		i++
 	}
 	(*a).Tour = append((*a).Tour, i)
+	tourLength := float64(len((*a).Tour))
 	(*a).Visited[i] = true
 	normalizedRating := ts.TownSlice[i].NormalizedRating
 	if tourLength > 1 {

--- a/antcolony.go
+++ b/antcolony.go
@@ -17,7 +17,7 @@ type AcoConfig struct {
 	MaximizeRating     bool               `json:"maximizeRating"`
 	VisitQuantity      int                `json:"visitQuantity"`
 	Verbose            bool               `json:"verbose"`
-	AvailabilityBounds AvailabilityBounds `json:"availabilityBounds"`
+	TripBounds         AvailabilityBounds `json:"tripBounds"`
 	MinimumTripUsage   float64            `json:"minimumTripUsage"`
 }
 
@@ -64,7 +64,7 @@ func importInputs(inputsJSON []byte) (AcoConfig, Towns, error) {
 			VisitQuantity:      0,
 			Verbose:            false,
 			MinimumTripUsage:   0.9,
-			AvailabilityBounds: AvailabilityBounds{
+			TripBounds: AvailabilityBounds{
 				Start: 0,
 				End:   0,
 			},

--- a/antcolony.go
+++ b/antcolony.go
@@ -8,15 +8,17 @@ import (
 
 //AcoConfig Configuration parameters for the ACO algorithm
 type AcoConfig struct {
-	NumberOfIterations int     `json:"numberOfIterations"`
-	TrailPreference    float64 `json:"trailPreference"`
-	RatingPreference   float64 `json:"ratingPreference"`
-	DistancePreference float64 `json:"distancePreference"`
-	PheremoneStrength  float64 `json:"pheremoneStrength"`
-	EvaporationRate    float64 `json:"evaporationRate"`
-	MaximizeRating     bool    `json:"maximizeRating"`
-	VisitQuantity      int     `json:"visitQuantity"`
-	Verbose            bool    `json:"verbose"`
+	NumberOfIterations int                `json:"numberOfIterations"`
+	TrailPreference    float64            `json:"trailPreference"`
+	RatingPreference   float64            `json:"ratingPreference"`
+	DistancePreference float64            `json:"distancePreference"`
+	PheremoneStrength  float64            `json:"pheremoneStrength"`
+	EvaporationRate    float64            `json:"evaporationRate"`
+	MaximizeRating     bool               `json:"maximizeRating"`
+	VisitQuantity      int                `json:"visitQuantity"`
+	Verbose            bool               `json:"verbose"`
+	AvailabilityBounds AvailabilityBounds `json:"availabilityBounds"`
+	MinimumTripUsage   float64            `json:"minimumTripUsage"`
 }
 
 // Inputs Input parameters, including configuration and towns
@@ -61,6 +63,11 @@ func importInputs(inputsJSON []byte) (AcoConfig, Towns, error) {
 			EvaporationRate:    .8,
 			VisitQuantity:      0,
 			Verbose:            false,
+			MinimumTripUsage:   0.9,
+			AvailabilityBounds: AvailabilityBounds{
+				Start: 0,
+				End:   0,
+			},
 		},
 		Towns: Towns{
 			IncludesHome: true,

--- a/town.go
+++ b/town.go
@@ -17,8 +17,8 @@ type Town struct {
 	VisitDuration      float64   `json:"visitDuration,omitEmpty"`
 	AvailabilityBounds `json:"availabilityBounds,omitEmpty"`
 	IsRequired         bool        `json:"isRequired"`
-	NormalizedRating   float64     `json:"-"`
 	TrailHistory       [][]float64 `json:"trailHistory,omitEmpty"`
+	normalizedRating   float64
 }
 
 // Towns is the collection of nodes for the TSP, with a matrix of the probability of traversing between each town
@@ -133,7 +133,7 @@ func (t *Town) updateTrails(ants []Ant, config AcoConfig) {
 func (ts *Towns) normalizeTownRatings(config AcoConfig) {
 	if config.RatingPreference == 0 {
 		for i := range ts.TownSlice {
-			(*ts).TownSlice[i].NormalizedRating = 0
+			(*ts).TownSlice[i].normalizedRating = 0
 		}
 	} else {
 		maxRating := ts.TownSlice[1].Rating
@@ -157,18 +157,18 @@ func (ts *Towns) normalizeTownRatings(config AcoConfig) {
 		maxDistanceFactor := 1.0 / minDistance
 		if minRating == maxRating {
 			for i := range ts.TownSlice {
-				(*ts).TownSlice[i].NormalizedRating = 0
+				(*ts).TownSlice[i].normalizedRating = 0
 			}
 		} else {
 			if config.MaximizeRating == true {
 				for i := range ts.TownSlice {
-					(*ts).TownSlice[i].NormalizedRating = config.RatingPreference * maxDistanceFactor * ((*ts).TownSlice[i].Rating - minRating) / (maxRating - minRating)
+					(*ts).TownSlice[i].normalizedRating = config.RatingPreference * maxDistanceFactor * ((*ts).TownSlice[i].Rating - minRating) / (maxRating - minRating)
 				}
 			}
 		}
 		if (*ts).IncludesHome {
 			(*ts).TownSlice[0].Rating = 0
-			(*ts).TownSlice[0].NormalizedRating = 0
+			(*ts).TownSlice[0].normalizedRating = 0
 		}
 	}
 }
@@ -185,14 +185,14 @@ func (ts *Towns) calculateProbabilityMatrix(config AcoConfig) {
 
 	for i, t := range (*ts).TownSlice {
 		for j := range (*ts).TownSlice[i].Trails {
-			probability := math.Pow(t.Trails[j], config.TrailPreference) * math.Pow((1.0/t.Distances[j]+t.NormalizedRating), config.DistancePreference)
+			probability := math.Pow(t.Trails[j], config.TrailPreference) * math.Pow((1.0/t.Distances[j]+t.normalizedRating), config.DistancePreference)
 			if math.IsInf(probability, 0) {
 				(*ts).probabilityMatrix[i][j] = 0
 			} else {
 				(*ts).probabilityMatrix[i][j] = probability
 			}
 			if config.Verbose {
-				noTrailProbability := math.Pow((1.0/t.Distances[j] + t.NormalizedRating), config.DistancePreference)
+				noTrailProbability := math.Pow((1.0/t.Distances[j] + t.normalizedRating), config.DistancePreference)
 				n := len((*ts).NoTrailProbabilityHistory) - 1
 
 				if math.IsInf(noTrailProbability, 0) {

--- a/town.go
+++ b/town.go
@@ -14,7 +14,7 @@ type Town struct {
 	Distances          []float64 `json:"distances,omitEmpty"`
 	Trails             []float64 `json:"trails,omitEmpty"`
 	Rating             float64   `json:"rating,omitEmpty"`
-	Cost               float64   `json:"cost,omitEmpty"`
+	VisitDuration      float64   `json:"visitDuration,omitEmpty"`
 	AvailabilityBounds `json:"availabilityBounds,omitEmpty"`
 	IsRequired         bool        `json:"isRequired"`
 	NormalizedRating   float64     `json:"-"`
@@ -194,6 +194,24 @@ func (ts *Towns) calculateProbabilityMatrix(config AcoConfig) {
 			}
 		}
 	}
+}
+
+func isAvailable(ts Towns, a *Ant, i int) bool {
+	visitRange := make([]float64, 2)
+	if len((*a).Tour) == 0 {
+		visitRange = []float64{ts.AvailabilityBounds.Start, ts.AvailabilityBounds.Start + ts.TownSlice[i].VisitDuration}
+	} else {
+		distance := ts.TownSlice[(*a).Tour[len((*a).Tour)-1]].Distances[i]
+		visitRange[0] = (*a).VisitSpan[len((*a).VisitSpan)-1][1] + distance
+		visitRange[1] = visitRange[0] + ts.TownSlice[i].VisitDuration
+
+		fmt.Println((*a).VisitSpan[len((*a).VisitSpan)-1], distance)
+	}
+
+	isAvailable := (ts.TownSlice[i].AvailabilityBounds.Start == 0 || ts.TownSlice[i].AvailabilityBounds.Start <= visitRange[0]) &&
+		(ts.TownSlice[i].AvailabilityBounds.End == 0 || ts.TownSlice[i].AvailabilityBounds.End >= visitRange[1])
+	fmt.Println(ts.TownSlice[i].AvailabilityBounds, visitRange, isAvailable)
+	return isAvailable
 }
 
 func (t *Town) jsonify() []byte {

--- a/town.go
+++ b/town.go
@@ -220,13 +220,11 @@ func isAvailable(ts Towns, a *Ant, i int) bool {
 		distance := ts.TownSlice[(*a).Tour[len((*a).Tour)-1]].Distances[i]
 		visitRange[0] = (*a).VisitSpan[len((*a).VisitSpan)-1][1] + distance
 		visitRange[1] = visitRange[0] + ts.TownSlice[i].VisitDuration
-
-		fmt.Println((*a).VisitSpan[len((*a).VisitSpan)-1], distance)
 	}
 
 	isAvailable := (ts.TownSlice[i].AvailabilityBounds.Start == 0 || ts.TownSlice[i].AvailabilityBounds.Start <= visitRange[0]) &&
-		(ts.TownSlice[i].AvailabilityBounds.End == 0 || ts.TownSlice[i].AvailabilityBounds.End >= visitRange[1])
-	fmt.Println(ts.TownSlice[i].AvailabilityBounds, visitRange, isAvailable)
+		(ts.TownSlice[i].AvailabilityBounds.End == 0 || ts.TownSlice[i].AvailabilityBounds.End >= visitRange[1]) &&
+		((*a).tripBounds.End == 0 || (*a).tripBounds.End >= visitRange[1])
 	return isAvailable
 }
 

--- a/town.go
+++ b/town.go
@@ -25,8 +25,7 @@ type Town struct {
 type Towns struct {
 	IncludesHome              bool `json:"includesHome"`
 	AvailabilityBounds        `json:"availabilityBounds,omitEmpty"`
-	TownSlice                 []Town `json:"towns"`
-	probabilityMatrix         [][]float64
+	TownSlice                 []Town        `json:"towns"`
 	ProbabilityHistory        [][][]float64 `json:"probabilityHistory,omitEmpty"`
 	NoTrailProbabilityHistory [][][]float64 `json:"noTrailProbabilityHistory,omitEmpty"`
 	requiredTownsVisited      []bool

--- a/town_test.go
+++ b/town_test.go
@@ -93,6 +93,7 @@ func TestIsAvailable(t *testing.T) {
 					2.0,
 					3.0,
 					4.0,
+					14.0,
 				},
 			},
 			Town{
@@ -107,6 +108,7 @@ func TestIsAvailable(t *testing.T) {
 					1.0,
 					2.0,
 					3.0,
+					13.0,
 				},
 			},
 			Town{
@@ -121,6 +123,7 @@ func TestIsAvailable(t *testing.T) {
 					0,
 					1.0,
 					2.0,
+					12.0,
 				},
 			},
 			Town{
@@ -135,6 +138,7 @@ func TestIsAvailable(t *testing.T) {
 					1.0,
 					0,
 					1.0,
+					11.0,
 				},
 			},
 			Town{
@@ -149,6 +153,22 @@ func TestIsAvailable(t *testing.T) {
 					2.0,
 					1.0,
 					0,
+					10.0,
+				},
+			},
+			Town{
+				AvailabilityBounds: AvailabilityBounds{
+					Start: 0,
+					End:   0,
+				},
+				VisitDuration: 1,
+				Distances: []float64{
+					14.0,
+					13.0,
+					12.0,
+					11.0,
+					10.0,
+					0,
 				},
 			},
 		},
@@ -162,6 +182,9 @@ func TestIsAvailable(t *testing.T) {
 			[]float64{0, 1},
 		},
 		costState: 1,
+		tripBounds: AvailabilityBounds{
+			End: 13,
+		},
 	}
 
 	if isAvailable(towns, &ant, 2) {
@@ -179,4 +202,9 @@ func TestIsAvailable(t *testing.T) {
 	if !isAvailable(towns, &ant, 4) {
 		t.Error("Expected town to be available when Start and End are 0")
 	}
+
+	if isAvailable(towns, &ant, 5) {
+		t.Error("Expected town to be unavailable when the cost of the trip is larger than the trip's End")
+	}
+
 }

--- a/town_test.go
+++ b/town_test.go
@@ -68,12 +68,11 @@ func TestProbabilityMatrix(t *testing.T) {
 
 	expectedProbabilityMatrix := [][]float64{[]float64{0, 1, 0.5}, []float64{1.5, 0, 1.5}, []float64{1.5, 2, 0}}
 
-	for i := range towns.ProbabilityMatrix {
-		for j := range towns.ProbabilityMatrix[i] {
-			if towns.ProbabilityMatrix[i][j] != expectedProbabilityMatrix[i][j] {
-				t.Error("ProbabilityMatrix for i:", i, "j:", j, "equals", towns.ProbabilityMatrix[i][j], "but expected", expectedProbabilityMatrix[i][j])
+	for i := range towns.probabilityMatrix {
+		for j := range towns.probabilityMatrix[i] {
+			if towns.probabilityMatrix[i][j] != expectedProbabilityMatrix[i][j] {
+				t.Error("ProbabilityMatrix for i:", i, "j:", j, "equals", towns.probabilityMatrix[i][j], "but expected", expectedProbabilityMatrix[i][j])
 			}
 		}
-
 	}
 }

--- a/town_test.go
+++ b/town_test.go
@@ -76,3 +76,107 @@ func TestProbabilityMatrix(t *testing.T) {
 		}
 	}
 }
+
+func TestIsAvailable(t *testing.T) {
+
+	towns := Towns{
+		TownSlice: []Town{
+			Town{
+				AvailabilityBounds: AvailabilityBounds{
+					Start: 1,
+					End:   4,
+				},
+				VisitDuration: 1,
+				Distances: []float64{
+					0,
+					1.0,
+					2.0,
+					3.0,
+					4.0,
+				},
+			},
+			Town{
+				AvailabilityBounds: AvailabilityBounds{
+					Start: 0,
+					End:   0,
+				},
+				VisitDuration: 1,
+				Distances: []float64{
+					1.0,
+					0,
+					1.0,
+					2.0,
+					3.0,
+				},
+			},
+			Town{
+				AvailabilityBounds: AvailabilityBounds{
+					Start: 0,
+					End:   2,
+				},
+				VisitDuration: 1,
+				Distances: []float64{
+					2.0,
+					1.0,
+					0,
+					1.0,
+					2.0,
+				},
+			},
+			Town{
+				AvailabilityBounds: AvailabilityBounds{
+					Start: 4,
+					End:   6,
+				},
+				VisitDuration: 1,
+				Distances: []float64{
+					3.0,
+					2.0,
+					1.0,
+					0,
+					1.0,
+				},
+			},
+			Town{
+				AvailabilityBounds: AvailabilityBounds{
+					Start: 0,
+					End:   0,
+				},
+				VisitDuration: 1,
+				Distances: []float64{
+					4.0,
+					3.0,
+					2.0,
+					1.0,
+					0,
+				},
+			},
+		},
+	}
+
+	ant := Ant{
+		Tour: []int{
+			1,
+		},
+		VisitSpan: [][]float64{
+			[]float64{0, 1},
+		},
+		costState: 1,
+	}
+
+	if isAvailable(towns, &ant, 2) {
+		t.Error("Expected town not to be available when the cost of the visit is larger than the town's End")
+	}
+
+	if !isAvailable(towns, &ant, 0) {
+		t.Error("Expected town to be available when the cost of the visit is between or equal to Start and End")
+	}
+
+	if isAvailable(towns, &ant, 3) {
+		t.Error("Expected town not to be available when the cost of the visit is smaller than the town's Start")
+	}
+
+	if !isAvailable(towns, &ant, 4) {
+		t.Error("Expected town to be available when Start and End are 0")
+	}
+}

--- a/town_test.go
+++ b/town_test.go
@@ -20,8 +20,8 @@ func TestZeroRatingPreference(t *testing.T) {
 
 	towns.normalizeTownRatings(config)
 	for i, town := range towns.TownSlice {
-		if town.NormalizedRating != 0 {
-			t.Error("NormalizedRating in town:", i, "equals", town.NormalizedRating, "but should be 0 when RatingPreference equals 0.")
+		if town.normalizedRating != 0 {
+			t.Error("NormalizedRating in town:", i, "equals", town.normalizedRating, "but should be 0 when RatingPreference equals 0.")
 		}
 	}
 
@@ -29,8 +29,8 @@ func TestZeroRatingPreference(t *testing.T) {
 
 	towns.normalizeTownRatings(config)
 	for i, town := range towns.TownSlice {
-		if town.NormalizedRating != 0 {
-			t.Error("NormalizedRating in town:", i, "equals", town.NormalizedRating, "but should be 0 when all Ratings submitted are equal.")
+		if town.normalizedRating != 0 {
+			t.Error("NormalizedRating in town:", i, "equals", town.normalizedRating, "but should be 0 when all Ratings submitted are equal.")
 		}
 	}
 
@@ -49,8 +49,8 @@ func TestNormalizeRatings(t *testing.T) {
 	expectedNormalizedRating := []float64{0, 0.5, 1}
 
 	for i, town := range towns.TownSlice {
-		if town.NormalizedRating != expectedNormalizedRating[i] {
-			t.Error("NormalizedRating in town:", i, "equals", town.NormalizedRating, "but expected", expectedNormalizedRating[i])
+		if town.normalizedRating != expectedNormalizedRating[i] {
+			t.Error("NormalizedRating in town:", i, "equals", town.normalizedRating, "but expected", expectedNormalizedRating[i])
 		}
 	}
 }


### PR DESCRIPTION
This adds the ability to set towns available within certain windows of time. This will allow venues to be set as closed at certain times. This implementation has the following limitations at the moment:

- Availability is a function of distance, which means that in order to use hours of availability, the `distance` parameter needs to be in units of time (i.e. Google's `duration` output from the [maps distance matrix api](https://developers.google.com/maps/documentation/distance-matrix/).
- The datatype used to calculate cost and availability is `float64`, and no `DateTime` units are handled. Therefore, all units must be in decimal form (i.e. calculated in 62.33 minutes rather than 1 hr, 2 min, 20 sec).
- At present, there is no handling of "Is Required" in conjuction with availability windows. As a result, any towns set as "isRequired" has a high likelihood of pushing other towns outside of their hours of availability. This will need to be resolved before both features can be used together